### PR TITLE
37 changing primary from from higher to lower id clears the current state

### DIFF
--- a/test-cases.md
+++ b/test-cases.md
@@ -10,3 +10,19 @@
 8. [x] "1 already exists"
 
 
+
+# KNOWN ISSUES
+
+## POSSIBILITY OF LOSING THE STATE OF THE GAME!
+
+### Situation
+1. server3 (ID = 3) is primary
+2. server2 (ID = 2 < 3) is down
+3. server2 is up and joins a group
+4. server2 sees itself as primary (has the lowest ID in the group(2, 3))
+   - but server3 sees itself also as primary (is still before the new election)
+5. the old primary (server3) still didn't send the current state of the game
+6. player1 sends a message to server2
+7. server2 processes the message since it sees itself as primary
+   - and tries to replicate it
+   - it means it tries to replicate a state that does not consider the state of the game before server2 joined the group


### PR DESCRIPTION
# Discuss the solution
- take a look at `test-cases.md`
- there is still a possibility of clearing the current state

# Problem
## Situation
1. server with ID == 3 is primary
2. server with ID == 2 (<3) is down
3. server with ID == 2 is up and joins a group

## Expected behaviour
4. server with ID == 2 gets the current status from primary and becomes a new primary

## Actual behaviour
4. server with ID == 2 overwrites what is saved on server with ID == 3 (we end up with deleting all the data)

